### PR TITLE
[WIP] Proposed scan interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ wheel
 pytest
 pytest-cov
 mock
+numpy
+scipy

--- a/src/parakeet/pose.py
+++ b/src/parakeet/pose.py
@@ -19,9 +19,9 @@ class PoseSet:
     orientations: np.ndarray
     shifts: np.ndarray
 
-    @property
-    def rotation_converter(self):
-        return R.from_matrix(self.orientations)
+    def __post_init__(self):
+        self._orientations = self.orientations
+        self.orientations = R.from_matrix(self._orientations)
 
     @property
     def euler_angles(self):
@@ -30,7 +30,7 @@ class PoseSet:
         The Euler angles are intrinsic, right handed rotations around ZYZ.
         This matches the convention used by XMIPP/RELION.
         """
-        return self.rotation_converter.as_euler(seq='ZYZ', degrees=True)
+        return self.orientations.as_euler(seq='ZYZ', degrees=True)
 
     @property
     def axis_angle(self):
@@ -38,7 +38,7 @@ class PoseSet:
 
         Magnitude of the rotation vector corresponds to the angle in radians.
         """
-        return self.rotation_converter.as_rotvec()
+        return self.orientations.as_rotvec()
 
     def __len__(self):
         n_orientations = self.orientations.shape[0]

--- a/src/parakeet/pose.py
+++ b/src/parakeet/pose.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+
+
+@dataclass
+class PoseSet:
+    """A description of poses of the system being simulated.
+
+    Parameters
+    __________
+
+    orientations : np.ndarray
+        (n, 3, 3) array of rotation matrices describing the pose of the system.
+    shifts : np.ndarray
+        (n, 3) array of how to shift the sample volume (units: A)
+    """
+    orientations: np.ndarray
+    shifts: np.ndarray
+
+    @property
+    def rotation_converter(self):
+        return R.from_matrix(self.orientations)
+
+    @property
+    def euler_angles(self):
+        """Euler angle representation of the orientations.
+
+        The Euler angles are intrinsic, right handed rotations around ZYZ.
+        This matches the convention used by XMIPP/RELION.
+        """
+        return self.rotation_converter.as_euler(seq='ZYZ', degrees=True)
+
+    @property
+    def axis_angle(self):
+        """Axis-angle representation of the orientations.
+
+        Magnitude of the rotation vector corresponds to the angle in radians.
+        """
+        return self.rotation_converter.as_rotvec()
+
+    def __len__(self):
+        n_orientations = self.orientations.shape[0]
+        n_shifts = self.shifts.shape[0]
+        if n_orientations != n_shifts:
+            raise RuntimeError(
+                'Number of orientations is different to the number of shifts.'
+            )
+        return n_shifts

--- a/src/parakeet/scan.py
+++ b/src/parakeet/scan.py
@@ -8,13 +8,81 @@
 # This code is distributed under the GPLv3 license, a copy of
 # which is included in the root directory of this package.
 #
-import numpy
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+from scipy.stats import special_ortho_group
 
 
-class Scan(object):
+@dataclass
+class PoseSet:
+    """A description of poses of the system being simulated.
+
+    Parameters
+    __________
+
+    orientations : np.ndarray
+        (n, 3, 3) array of rotation matrices describing the pose of the system.
+    shifts : np.ndarray
+        (n, 3) array of how to shift the sample volume (units: A)
     """
-    A class to encapsulate an scan
+    orientations: np.ndarray
+    shifts: np.ndarray
 
+    @property
+    def rotation_converter(self):
+        return R.from_matrix(self.orientations)
+
+    @property
+    def euler_angles(self):
+        """Euler angle representation of the orientations.
+
+        The Euler angles are intrinsic, right handed rotations around ZYZ.
+        This matches the convention used by XMIPP/RELION.
+        """
+        return self.rotation_converter.as_euler(seq='ZYZ', degrees=True)
+
+    @property
+    def axis_angle(self):
+        """Axis-angle representation of the orientations.
+
+        Magnitude of the rotation vector corresponds to the angle in radians.
+        """
+        return self.rotation_converter.as_rotvec()
+
+    def __len__(self):
+        n_orientations = self.orientations.shape[0]
+        n_shifts = self.shifts.shape[0]
+        if n_orientations != n_shifts:
+            raise RuntimeError(
+                'Number of orientations is different to the number of shifts.'
+            )
+        return n_shifts
+
+
+class Scan(ABC):
+    """A base class defining the interface for image sampling in a simulation.
+    """
+
+    @property
+    @abstractmethod
+    def poses(self) -> PoseSet:
+        pass
+
+    @property
+    @abstractmethod
+    def exposure_times(self) -> np.ndarray:
+        pass
+
+    def __len__(self) -> int:
+        """The number of images to sample"""
+        return len(self.poses)
+
+
+class SingleAxisScan(object):
+    """A scan of angles around a single rotation axis.
     """
 
     def __init__(self, axis=None, angles=None, positions=None, exposure_time=None):
@@ -37,7 +105,7 @@ class Scan(object):
         else:
             self.angles = angles
         if positions is None:
-            self.positions = numpy.zeros(shape=len(angles), dtype=numpy.float32)
+            self.positions = np.zeros(shape=len(angles), dtype=np.float32)
         else:
             self.positions = positions
         assert len(self.angles) == len(self.positions)
@@ -53,17 +121,44 @@ class Scan(object):
         return len(self.angles)
 
 
+class UniformAngularScan(Scan):
+    """A uniform scan of orientations, no shifts.
+    """
+
+    def __init__(self, n: int):
+        """
+        Parameters
+        __________
+        n : int
+            The number of uniform orientational samples
+        """
+        self.n = int(n)
+
+    @property
+    def exposure_times(self) -> np.ndarray:
+        pass
+
+    @property
+    def poses(self) -> PoseSet:
+        # Draw n uniform samples from SO(3)
+        orientations = special_ortho_group.rvs(dim=3, size=self.n)
+        shifts = np.zeros(shape=(self.n, 3))
+
+        # Create and return PoseSet object
+        return PoseSet(orientations, shifts)
+
+
 def new(
-    mode="still",
-    axis=(0, 1, 0),
-    angles=None,
-    positions=None,
-    start_angle=0,
-    step_angle=0,
-    start_pos=0,
-    step_pos=0,
-    num_images=1,
-    exposure_time=1,
+        mode="still",
+        axis=(0, 1, 0),
+        angles=None,
+        positions=None,
+        start_angle=0,
+        step_angle=0,
+        start_pos=0,
+        step_pos=0,
+        num_images=1,
+        exposure_time=1,
 ):
     """
     Create an scan
@@ -91,29 +186,29 @@ def new(
         if mode == "still":
             angles = [start_angle]
         elif mode == "tilt_series":
-            angles = start_angle + step_angle * numpy.arange(num_images)
+            angles = start_angle + step_angle * np.arange(num_images)
         elif mode == "dose_symmetric":
-            angles = start_angle + step_angle * numpy.arange(num_images)
-            angles = numpy.array(sorted(angles, key=lambda x: abs(x)))
+            angles = start_angle + step_angle * np.arange(num_images)
+            angles = np.array(sorted(angles, key=lambda x: abs(x)))
         elif mode == "helical_scan":
-            angles = start_angle + step_angle * numpy.arange(num_images)
+            angles = start_angle + step_angle * np.arange(num_images)
         else:
             raise RuntimeError(f"Scan mode not recognised: {mode}")
     if positions is None:
         if mode == "still":
             positions = [start_pos]
         elif mode == "tilt_series":
-            positions = numpy.full(
-                shape=len(angles), fill_value=start_pos, dtype=numpy.float32
+            positions = np.full(
+                shape=len(angles), fill_value=start_pos, dtype=np.float32
             )
         elif mode == "dose_symmetric":
-            positions = numpy.full(
-                shape=len(angles), fill_value=start_pos, dtype=numpy.float32
+            positions = np.full(
+                shape=len(angles), fill_value=start_pos, dtype=np.float32
             )
         elif mode == "helical_scan":
-            positions = start_pos + step_pos * numpy.arange(num_images)
+            positions = start_pos + step_pos * np.arange(num_images)
         else:
             raise RuntimeError(f"Scan mode not recognised: {mode}")
-    return Scan(
+    return SingleAxisScan(
         axis=axis, angles=angles, positions=positions, exposure_time=exposure_time
     )

--- a/src/parakeet/scan.py
+++ b/src/parakeet/scan.py
@@ -9,57 +9,11 @@
 # which is included in the root directory of this package.
 #
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 
 import numpy as np
-from scipy.spatial.transform import Rotation as R
 from scipy.stats import special_ortho_group
 
-
-@dataclass
-class PoseSet:
-    """A description of poses of the system being simulated.
-
-    Parameters
-    __________
-
-    orientations : np.ndarray
-        (n, 3, 3) array of rotation matrices describing the pose of the system.
-    shifts : np.ndarray
-        (n, 3) array of how to shift the sample volume (units: A)
-    """
-    orientations: np.ndarray
-    shifts: np.ndarray
-
-    @property
-    def rotation_converter(self):
-        return R.from_matrix(self.orientations)
-
-    @property
-    def euler_angles(self):
-        """Euler angle representation of the orientations.
-
-        The Euler angles are intrinsic, right handed rotations around ZYZ.
-        This matches the convention used by XMIPP/RELION.
-        """
-        return self.rotation_converter.as_euler(seq='ZYZ', degrees=True)
-
-    @property
-    def axis_angle(self):
-        """Axis-angle representation of the orientations.
-
-        Magnitude of the rotation vector corresponds to the angle in radians.
-        """
-        return self.rotation_converter.as_rotvec()
-
-    def __len__(self):
-        n_orientations = self.orientations.shape[0]
-        n_shifts = self.shifts.shape[0]
-        if n_orientations != n_shifts:
-            raise RuntimeError(
-                'Number of orientations is different to the number of shifts.'
-            )
-        return n_shifts
+from parakeet.pose import PoseSet
 
 
 class Scan(ABC):


### PR DESCRIPTION
Here is a proposal for a new `Scan` interface, submitting for feedback before trying to refactor existing `Scan` objects and interface these objects with the simulation code.

Previously, `Scan` objects could scan rotations around a single axis and optionally shift the sample between exposures during the scan.

With the proposed interface, an arbitrary set of poses can be simulated. The poses, comprising orientations and shifts, are defined in a new `PoseSet` object. 
- Orientations are described as an (n, 3, 3) array of rotation matrices with convenience functions for generating both Euler angle and axis-angle representations
- Shifts are described as an (n, 3) array of shifts, in angstroms, to be applied to the sample volume.

This implementation adds a scipy dependency, if you feel strongly about this, we could extract and reimplement the features used here.