### PR TITLE
Feature: Add support for CIF assembly_index via config.yaml

### DIFF
--- a/src/parakeet/config.py
+++ b/src/parakeet/config.py
@@ -192,6 +192,16 @@ class CoordinateFile(BaseModel):
         None, description="The filename of the atomic coordinates to use (*.pdb, *.cif)"
     )
 
+    assembly_index: int = Field(
+        0,
+        description=(
+            "The assembly index to use for the given assembly index to be applied "
+            "This is only used if the filename is set and the file contains "
+            "multiple assemblies. If the file does not contain multiple assemblies "
+            "then this will be ignored."
+        ),
+    )
+
     recentre: bool = Field(True, description="Recentre the coordinates")
 
     scale: float = Field(1, description="Scale the coordinates x' = x * scale")
@@ -232,6 +242,16 @@ class LocalMolecule(BaseModel):
 
     filename: str = Field(
         description="The filename of the atomic coordinates to use (*.pdb, *.cif)"
+    )
+
+    assembly_index: int = Field(
+        0,
+        description=(
+            "The assembly index to use for the given assembly index to be applied "
+            "This is only used if the filename is set and the file contains "
+            "multiple assemblies. If the file does not contain multiple assemblies "
+            "then this will be ignored."
+        ),
     )
 
     instances: Union[int, List[MoleculePose]] = Field(

--- a/src/parakeet/sample/__init__.py
+++ b/src/parakeet/sample/__init__.py
@@ -615,7 +615,7 @@ class AtomData(object):
         return AtomData(data=pandas.DataFrame(create_atom_data(structure)))
 
     @classmethod
-    def from_gemmi_file(Class, filename):
+    def from_gemmi_file(Class, filename, assembly_index=0):
         """
         Read the sample from a file
 
@@ -633,7 +633,7 @@ class AtomData(object):
         # Create ensemble with default first biological assembly
         if len(structure.assemblies) > 0 and len(structure) > 0:
             structure = gemmi.make_assembly(
-                structure.assemblies[0],
+                structure.assemblies[assembly_index],
                 structure[0],
                 gemmi.HowToNameCopiedChain.AddNumber,
             )

--- a/src/parakeet/sample/_add_molecules.py
+++ b/src/parakeet/sample/_add_molecules.py
@@ -131,17 +131,22 @@ def add_multiple_molecules(sample, molecules):
         if len(items) == 0:
             continue
 
-        # Print some info
-        logger.info("Adding %d %s molecules" % (len(items), name))
-
         # Get the filename of the PDB entry
         if mtype == "pdb":
             filename = parakeet.data.get_pdb(name)
         elif mtype == "local":
             filename = name
+        
+        assembly_index = 0
+        if "assembly_index" in value:
+            assembly_index = int(value["assembly_index"])
+            print("use user passed assembly index %d" % assembly_index)
+        
+        # Print some info
+        logger.info("Adding %d %s molecules with assembly_index %d" % (len(items), name, assembly_index))
 
         # Get the atom data
-        atoms = AtomData.from_gemmi_file(filename)
+        atoms = AtomData.from_gemmi_file(filename, assembly_index)
         atoms.data = recentre(atoms.data)
         atom_data[name] = atoms
 


### PR DESCRIPTION
📌 Context

CIF files (especially from the PDB archive) often include multiple biological assemblies. Previously, parakeet always defaulted to using the first assembly, which limited flexibility for users working with multimeric structures (e.g. dimers, trimers, etc.).
✨ What’s new

This small PR adds support for optionally specifying which assembly index to use when parsing a CIF file.
✅ Changes overview

    config.yaml:

        Adds a new optional field: assembly_index

        Default is 0 (use first assembly), but users can override it.

    src/parakeet/config.py:

        Adds assembly_index: int = 0 to the CoordinateFile config schema

    src/parakeet/sample/_add_molecules.py:

        The assembly_index is passed to the CIF parser (via Biotite)

    src/parakeet/sample/__init__.py:

        Minimal update to ensure proper propagation of the config field