### PR TITLE
Fix: combine random and defined position/angles (#80)

### DIFF
--- a/src/parakeet/sample/_add_molecules.py
+++ b/src/parakeet/sample/_add_molecules.py
@@ -170,10 +170,20 @@ def add_multiple_molecules(sample, molecules):
 
     # Put the molecules in the sample
     logger.info("Placing molecules:")
-    if any(p is None or len(p) == 0 for p in all_positions):
-        all_positions = distribute_particles_uniformly(
-            shape_volume_object(sample.centre, sample.shape), np.array(all_radii)
+    
+    # Check if any random positions need to be generated
+    random_indices = [i for i, p in enumerate(all_positions) if p is None or len(p) == 0]
+    
+    if random_indices:
+        # Only generate positions for molecules that need them
+        random_radii = [all_radii[i] for i in random_indices]
+        random_positions = distribute_particles_uniformly(
+            shape_volume_object(sample.centre, sample.shape), np.array(random_radii)
         )
+        
+        # Update only the positions that were None
+        for i, random_pos in zip(random_indices, random_positions):
+            all_positions[i] = random_pos
 
     # Set the positions and orientations by molecule
     positions = defaultdict(list)


### PR DESCRIPTION
Way to fix issue #80. Before, it was generating random positions for every molecule if one of the entries required random positions. This way it should split between entries that need random positions and entries that have defined ones. Tested.